### PR TITLE
Run `brew` as regular user in place of root

### DIFF
--- a/install_scripts/install_dependencies.sh
+++ b/install_scripts/install_dependencies.sh
@@ -1,14 +1,25 @@
 #!/bin/bash
 
+userCmd() {
+	case "$(id -u)" in
+	  0) sudo -u "$SUDO_USER" "$@" ;;
+	  *) "$@"
+	esac
+}
+
 if [ "$(uname)" == "Darwin" ]; then
 	echo "--- Intall Dependencies for Mac OS ---"
-	brew update
-	brew list openssl || brew install openssl
-	brew list xctool || brew install xctool
-	brew list pkg-config || brew install pkg-config
-	brew list cmake || brew install cmake
-	brew list gmp || brew install gmp
-	brew list boost || brew install boost
+
+	userCmd sh -c '
+		packages="openssl xctool pkg-config cmake gmp boost"
+
+		brew update
+
+		for pkg in $packages
+		do
+			brew list "$pkg" | brew install "$pkg"
+		done
+	'
 else
 	echo "--- Intall Dependencies for Linux Ubuntu ---"
 	CC=`lsb_release -rs | cut -c 1-2`
@@ -16,7 +27,7 @@ else
 	if [[ $VER -gt 15 ]]; then
 		apt-get install -y software-properties-common
 		apt-get update
-		apt-get install -y cmake git build-essential libssl-dev libgmp-dev python 
+		apt-get install -y cmake git build-essential libssl-dev libgmp-dev python
 		apt-get install -y libboost-dev
 		apt-get install -y libboost-{chrono,log,program-options,date-time,thread,system,filesystem,regex,test}-dev
 	else
@@ -24,7 +35,7 @@ else
 		add-apt-repository -y ppa:george-edison55/cmake-3.x
 		add-apt-repository -y ppa:kojoley/boost
 		apt-get update
-		apt-get install -y cmake git build-essential libssl-dev libgmp-dev python 
+		apt-get install -y cmake git build-essential libssl-dev libgmp-dev python
 		apt-get install -y libboost-all-dev
 #		sudo apt-get install -y libboost1.58-dev
 #		sudo apt-get install -y libboost-{chrono,log,program-options,date-time,thread,system,filesystem,regex,test}1.58-dev


### PR DESCRIPTION
Fixes #4

Instead of running `brew` with sudo privileges, this wrapper runs it as a normal user by dropping privileges, which is the intended use case for Homebrew.